### PR TITLE
Upgrade mapbox-gl-draw to 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "@mapbox/mapbox-gl-draw": "^0.19.1",
+    "@mapbox/mapbox-gl-draw": "^1.0.0",
     "broccoli-funnel": "^1.2.0",
     "broccoli-merge-trees": "^2.0.0",
     "ember-assign-polyfill": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -106,9 +106,9 @@
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/@mapbox/gl-matrix/-/gl-matrix-0.0.1.tgz#e5126aab4d64c36b81c7a97d0ae0dddde5773d2b"
 
-"@mapbox/mapbox-gl-draw@^0.19.1":
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/@mapbox/mapbox-gl-draw/-/mapbox-gl-draw-0.19.1.tgz#d9e164a0889da77c5e85deef55c604d17b35c559"
+"@mapbox/mapbox-gl-draw@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@mapbox/mapbox-gl-draw/-/mapbox-gl-draw-1.0.0.tgz#0c0a00a16ec91b269966b04cf6f883f806ad3821"
   dependencies:
     "@mapbox/geojson-area" "^0.2.1"
     "@mapbox/geojson-normalize" "0.0.1"


### PR DESCRIPTION
We should bump this to 1.0 which fixes a lot of issues (one of which is the backspace key not working when the trash control is used).