### PR TITLE
Allow empty

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,8 @@ module.exports = {
   treeForPublic(vendorTree) {
     const mapboxGlDrawTree = new Funnel(Path.dirname(require.resolve('@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.js')), {
       srcDir: '/svg',
-      destDir: '/assets/images'
+      destDir: '/assets/images',
+      allowEmpty: true
     });
 
     if (vendorTree) {


### PR DESCRIPTION
Build Error (Funnel)

You specified a `"srcDir": /svg` which does not exist and did not specify `"allowEmpty": true`.